### PR TITLE
ローカル開発環境構築時の手順見直し

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:23.11.0-bookworm
 WORKDIR /app
-COPY package.json .
+COPY package*.json .
 RUN npm install
 COPY . .

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 docker compose build
 ```
 
+#### ホスト側にnode_modulesをインストール
+ローカルで開発する際、node_modulesがないと参照エラーが発生してしまう
+また、docker-compose.yml でボリュームをマウントするときにホスト側のnode_moduleが空だとコンテナ側のnode_moduleも空で上書きしてしまう
+```
+docker compose run --rm node npm install
+```
+
 #### 開発
 ```
 docker compose up -d


### PR DESCRIPTION
# 説明
node_modulesが存在しない状態でdocker-compose.ymlでボリュームをマウントすると、コンテナ側のnode_modulesを消してしまう。
Dockerfileのビルド後にdocker compose run でnode_modulesをインストールすることでホスト側にもnode_modulesを反映させる。
この手順はnode_modulesが存在しない場合のみ実行すれば良いので、READMEに手順を追記することにした。